### PR TITLE
WIP: cleanup CCOS-disk-utils

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,13 +1,13 @@
 ---
 BasedOnStyle: Google
-AccessModifierOffset: '-4'
-AllowShortBlocksOnASingleLine: 'false'
-AllowShortCaseLabelsOnASingleLine: 'false'
+AccessModifierOffset: -4
+AllowShortBlocksOnASingleLine: 'Never'
+AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Empty
-AllowShortIfStatementsOnASingleLine: 'false'
-AllowShortLoopsOnASingleLine: 'false'
-ColumnLimit: '120'
-IndentWidth: '2'
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+ColumnLimit: 120
+IndentWidth: 2
 PointerAlignment: Left
 
 ...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.10)
 
 project(ccos_disk_tool)
 
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED True)
+
 set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${SOURCE_DIR})
 

--- a/api_test.c
+++ b/api_test.c
@@ -54,17 +54,17 @@ uint8_t test_inode_data[] = {
 
 int check_image_test() {
   uint8_t data[0x200] = {0};
-  ASSERT(ccos_check_image(data) == 0);
+  ASSERT(is_image_supported(data) == 1);
   data[0] = 'I';
   data[1] = 'M';
   data[2] = 'D';
   data[3] = ' ';
-  ASSERT(ccos_check_image(data) == -1);
+  ASSERT(is_image_supported(data) == 0);
   memset(data, 0, 0x200);
   data[0] = 0xEB;
   data[2] = 0x90;
   *((uint16_t *)(&data[0x1FE])) = 0xAA55;
-  ASSERT(ccos_check_image(data) == -1);
+  ASSERT(is_image_supported(data) == 0);
   return 0;
 }
 

--- a/ccos_image.c
+++ b/ccos_image.c
@@ -674,8 +674,16 @@ ccos_inode_t* ccos_create_dir(ccfs_handle ctx, ccos_inode_t* parent_dir, const c
 
   sprintf(filename, "%s%s", directory_name, dir_suffix);
 
-  uint8_t directory_contents = CCOS_DIR_LAST_ENTRY_MARKER;
-  ccos_inode_t* new_directory = ccos_add_file(ctx, parent_dir, &directory_contents, get_dir_default_size(ctx), filename, image_data, image_size);
+  size_t directory_size = get_dir_default_size(ctx);
+  uint8_t* directory_contents = calloc(directory_size, sizeof(uint8_t));
+  if (directory_contents == NULL) {
+    fprintf(stderr, "Unabled to create directory: Unable to allocate memory for directory!\n");
+    return NULL;
+  }
+
+  directory_contents[0] = CCOS_DIR_LAST_ENTRY_MARKER;
+
+  ccos_inode_t* new_directory = ccos_add_file(ctx, parent_dir, directory_contents, directory_size, filename, image_data, image_size);
   free(filename);
 
   if (new_directory == NULL) {

--- a/ccos_image.c
+++ b/ccos_image.c
@@ -24,10 +24,10 @@ static int is_imd_image(const uint8_t* data) {
   return data[0] == 'I' && data[1] == 'M' && data[2] == 'D' && data[3] == ' ';
 }
 
-int ccos_check_image(const uint8_t* file_data) {
+int is_image_supported(const uint8_t* file_data) {
   if (is_fat_image(file_data)) {
     fprintf(stderr, "FAT image is found; return.\n");
-    return -1;
+    return 0;
   }
 
   if (is_imd_image(file_data)) {
@@ -36,10 +36,10 @@ int ccos_check_image(const uint8_t* file_data) {
             "image (.img) before using.\n"
             "\n"
             "(You can use Disk-Utilities from here: https://github.com/keirf/Disk-Utilities)\n");
-    return -1;
+    return 0;
   }
 
-  return 0;
+  return 1;
 }
 
 uint16_t ccos_file_id(const ccos_inode_t* inode) {

--- a/ccos_image.h
+++ b/ccos_image.h
@@ -19,9 +19,9 @@ typedef enum { UNKNOWN, DATA, EMPTY } block_type_t;
  *
  * @param[in]  file_data  The file.
  *
- * @return     0 if valid, -1 otherwise.
+ * @return     1 if supported, 0 otherwise.
  */
-int ccos_check_image(const uint8_t* file_data);
+int is_image_supported(const uint8_t* file_data);
 
 /**
  * @brief      Get the file ID.

--- a/ccos_image.h
+++ b/ccos_image.h
@@ -191,11 +191,11 @@ int ccos_get_image_map(ccfs_handle ctx, const uint8_t* data, size_t data_size, b
 /**
  * @brief      Read file contents into memory buffer.
  *
- * @param[in]  ctx         Filesystem context handle.
- * @param[in]  file        File to read.
- * @param[in]  image_data  CCOS image data.
- * @param      file_data   The file data.
- * @param      file_size   The file size.
+ * @param[in]   ctx         Filesystem context handle.
+ * @param[in]   file        File to read.
+ * @param[in]   image_data  CCOS image data.
+ * @param[out]  file_data   The file data.
+ * @param[out]  file_size   The file size.
  *
  * @return     0 on success, -1 otherwise.
  */

--- a/ccos_image.h
+++ b/ccos_image.h
@@ -10,8 +10,6 @@ typedef struct {
   uint8_t patch;
 } version_t;
 
-typedef struct ccos_inode_t_ ccos_inode_t;
-
 typedef enum { UNKNOWN, DATA, EMPTY } block_type_t;
 
 /**

--- a/ccos_image.h
+++ b/ccos_image.h
@@ -268,13 +268,14 @@ int ccos_validate_file(ccfs_handle ctx, const ccos_inode_t* file);
 /**
  * @brief      Return amount of free space available in the image.
  *
- * @param[in]  ctx        Filesystem context handle.
- * @param      data       CCOS image data.
- * @param[in]  data_size  Data size.
+ * @param[in]  ctx         Filesystem context handle.
+ * @param[in]  data        CCOS image data.
+ * @param[in]  data_size   Data size.
+ * @param[out  free_space  TODO.
  *
  * @return     Free space in the image, in bytes.
  */
-size_t ccos_calc_free_space(ccfs_handle ctx, uint8_t* data, size_t data_size);
+int ccos_calc_free_space(ccfs_handle ctx, uint8_t* data, size_t data_size, size_t* free_space);
 
 /**
  * @brief      Overwrite file contents with the given data.
@@ -364,6 +365,6 @@ int ccos_set_image_label(ccfs_handle ctx, uint8_t* data, size_t data_size, const
  *
  * @return     Image data on success, NULL otherwise.
  */
-uint8_t* ccos_create_new_image(ccfs_handle ctx, size_t blocks);
+int ccos_create_new_image(ccfs_handle ctx, size_t blocks, uint8_t** out);
 
 #endif  // CCOS_IMAGE_H

--- a/ccos_private.h
+++ b/ccos_private.h
@@ -334,7 +334,7 @@ int parse_directory_data(ccfs_handle ctx, uint8_t* image_data,
  *
  * @return     0 on success, -1 otherwise.
  */
-int get_block_data(ccfs_handle ctx, uint16_t block, const uint8_t* data, const uint8_t** start, size_t* size);
+int get_block_data(ccfs_handle ctx, uint16_t block, uint8_t* data, uint8_t** start, size_t* size);
 
 /**
  * @brief      Return info about free blocks in a CCOS image.

--- a/main.c
+++ b/main.c
@@ -241,7 +241,7 @@ int main(int argc, char** argv) {
     return -1;
   }
 
-  if (ccos_check_image(file_contents) == -1) {
+  if (!is_image_supported(file_contents)) {
     fprintf(stderr, "Unable to get superblock: invalid image format!\n");
     free(file_contents);
     return -1;

--- a/main.c
+++ b/main.c
@@ -235,7 +235,7 @@ int main(int argc, char** argv) {
 
   uint8_t* file_contents = NULL;
   size_t file_size = 0;
-  if (read_file(path, &file_contents, &file_size) == -1) {
+  if (read_file(path, &file_contents, &file_size)) {
     fprintf(stderr, "Unable to read disk image file!\n");
     print_usage();
     return -1;
@@ -251,10 +251,20 @@ int main(int argc, char** argv) {
   switch (mode) {
     case MODE_PRINT: {
       res = print_image_info(ctx, path, file_contents, file_size, short_format);
-      if (res == 0) {
-        size_t free_bytes = ccos_calc_free_space(ctx, file_contents, file_size);
+      if (res) {
+        fprintf(stderr, "TODO");
+        break;
+      }
+
+      size_t free_bytes = 0;
+
+      int ret = ccos_calc_free_space(ctx, file_contents, file_size, &free_bytes);
+      if (ret) {
+        fprintf(stderr, "TODO");
+      } else {
         printf("Free space: " SIZE_T " bytes.\n", free_bytes);
       }
+
       break;
     }
     case MODE_DUMP: {


### PR DESCRIPTION
One more step to make this library safe to use in a future FUSE driver.

Too much stuff happened during the refactoring process. If necessary, I'll split this PR into three separate ones.

Done:

* use errno codes instead of -1
* fix compilation on old compiler, use C99 standard
* fix all known memory leaks
* fix UB in ccos_create_dir
* fix clang format

In progress:

* thinking about replacing the errno codes with own error codes (this will allow remove all error printf's)
* one more valgrind run, one more sanitizers check and maybe check project with sonarqube
* doxygen